### PR TITLE
solution to strptime dealing with non English locale

### DIFF
--- a/R/find-dam-first-last-lines.R
+++ b/R/find-dam-first-last-lines.R
@@ -39,6 +39,7 @@ find_dam_first_last_lines <- function(file,
   datetimes_dt[, read_id := cumsum(data_type == "CT" | data_type == "0")]
   datetimes_dt <- datetimes_dt[status == 1]
   datetimes_dt <- datetimes_dt[, datetime := paste(date,time, sep=" ")]
+  lct <- Sys.getlocale("LC_TIME"); Sys.setlocale("LC_TIME", "C")
   suppressWarnings(
     datetimes_dt <- datetimes_dt[, datetime_posix  := as.POSIXct(strptime(datetime,"%d %b %y %H:%M:%S",tz=tz))]
   )


### PR DESCRIPTION
In some system if the local is not set to english datetime, the system wil fail to convert the datetime column to datetime_posix, returning "Non data in the selected range" error 
Not sure if DAM systems is always saving in English format or also taking the host computer datetime to format the date column.