### PR TITLE
Provide column names as vector, not CSV

### DIFF
--- a/R/load-dam.R
+++ b/R/load-dam.R
@@ -59,7 +59,7 @@ load_dam <- function(metadata, date_format="%d %b %y", FUN=NULL, ...){
                                                     date_format=date_format)
                               )
                     ),
-               by="path,start_datetime,stop_datetime"]
+               by=c("path","start_datetime","stop_datetime")]
 
   d <- behavr::bind_behavr_list(s[,data])
 


### PR DESCRIPTION
data.table is considering deprecating this approach to specifying `by=`, namely, as a comma-separated string of columns, because of the inconsistency it induces.

Please follow up in https://github.com/Rdatatable/data.table/issues/4357 if you have further input about this plan.